### PR TITLE
Remove `exhaustive`

### DIFF
--- a/taxi/src/main/java/com/vlad1m1r/bltaxi/taxi/TaxiViewModel.kt
+++ b/taxi/src/main/java/com/vlad1m1r/bltaxi/taxi/TaxiViewModel.kt
@@ -53,7 +53,7 @@ class TaxiViewModel(
                         isLoading.set(false)
                         isErrorShown.set(true)
                     }
-                }.exhaustive
+                }
             }
         }
     }


### PR DESCRIPTION
`exhaustive` isn't required here because the `sealed class` pattern is used.